### PR TITLE
Allow public url to be set to any value

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@ export const BREAKPOINTS = {
   large: '(min-width: 1200px)',
 };
 
-const publicURL = typeof window !== 'undefined' && window.SVG_JAR_PUBLIC_URL
+const publicURL = typeof window !== 'undefined' && typeof window.SVG_JAR_PUBLIC_URL !== 'undefined'
   ? window.SVG_JAR_PUBLIC_URL
   : '/';
 


### PR DESCRIPTION
Instead of checking whether or not `window.SVG_JAR_PUBLIC_URL` is truthy, this checks whether there is any value set at all. This allows setting public url to a blank string, which seems to be the correct setting when ember asset fingerprinting is set to use a prepend.

As a hack in our app, we are currently setting it to a space `' '` which seems to be working for now! 🤞